### PR TITLE
Fix UB in test_bad_deser

### DIFF
--- a/epserde/tests/test_bad_deser.rs
+++ b/epserde/tests/test_bad_deser.rs
@@ -16,14 +16,7 @@ fn test_wrong_endianess() {
     let data = 1337_usize;
 
     let len = 20;
-    let mut v = unsafe {
-        Vec::from_raw_parts(
-            std::alloc::alloc_zeroed(std::alloc::Layout::from_size_align(len, 16).unwrap()),
-            len,
-            len,
-        )
-    };
-    assert!(v.as_ptr() as usize % 16 == 0, "{:p}", v.as_ptr());
+    let mut v = Vec::with_capacity(len);
     let mut buf = std::io::Cursor::new(&mut v);
 
     let schema = data.serialize_with_schema(&mut buf).unwrap();


### PR DESCRIPTION
In `test_bad_deser`, a `Vec<u8>` is created using an alignment of 16. However, when the `Vec<u8>` is dropped, it deallocates using a layout with an alignment of `align_of::<T>()`. For `u8`, this means that the memory allocated with a layout of `size = len, align = 16` will be deallocated with a layout of `size = len, align = 1`. Creating a `Vec` in this way is a violation of the safety conditions of `from_raw_parts`, which requires that "`T` needs to have the same alignment as what `ptr` was allocated with".