### PR TITLE
Feature gate mmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ let t: [usize; 1000] =
 assert_eq!(s, t);
 
 // In this case we map the data structure into memory
+//
+// Note: requires the `mmap` feature.
 let u: MemCase<&[usize; 1000]> = 
     <[usize; 1000]>::mmap(&file, Flags::empty())?;
 

--- a/epserde/Cargo.toml
+++ b/epserde/Cargo.toml
@@ -19,10 +19,11 @@ anyhow = "1.0.79"
 sealed = "0.5.0"
 maligned = "0.2.1"
 common_traits = "0.10.2"
-mem_dbg = {version="0.2.1", features=["maligned", "mmap-rs"]}
+mem_dbg = { version="0.2.4", features=["maligned", "derive"], default-features=false }
 
 [features]
-default = ["std", "mmap-rs", "derive"]
+default = ["std", "mmap", "derive"]
 derive = ["epserde-derive"]
-std = ["alloc"]
+std = ["alloc", "mem_dbg/std"]
 alloc = []
+mmap = ["mmap-rs", "mem_dbg/mmap-rs"]

--- a/epserde/src/deser/mem_case.rs
+++ b/epserde/src/deser/mem_case.rs
@@ -42,6 +42,7 @@ impl core::default::Default for Flags {
 
 impl Flags {
     /// Translates internal flags to `mmap_rs` flags.
+    #[cfg(feature = "mmap")]
     pub(crate) fn mmap_flags(&self) -> mmap_rs::MmapFlags {
         let mut flags: mmap_rs::MmapFlags = mmap_rs::MmapFlags::empty();
         if self.contains(Self::SEQUENTIAL) {
@@ -76,6 +77,7 @@ pub enum MemBackend {
     Memory(Box<[MemoryAlignment]>),
     /// The backend is the result to a call to `mmap()`.
     /// This variant is returned by [`crate::deser::Deserialize::load_mmap`] and [`crate::deser::Deserialize::mmap`].
+    #[cfg(feature = "mmap")]
     Mmap(mmap_rs::Mmap),
 }
 
@@ -89,6 +91,7 @@ impl MemBackend {
                     mem.len() * size_of::<MemoryAlignment>(),
                 )
             }),
+            #[cfg(feature = "mmap")]
             MemBackend::Mmap(mmap) => Some(mmap),
         }
     }

--- a/epserde/src/deser/mod.rs
+++ b/epserde/src/deser/mod.rs
@@ -127,6 +127,9 @@ pub trait Deserialize: TypeHash + ReprHash + DeserializeInner {
     ///
     /// The behavior of `mmap()` can be modified by passing some [`Flags`]; otherwise,
     /// just pass `Flags::empty()`.
+    /// 
+    /// Requires the `mmap` feature.
+    #[cfg(feature = "mmap")]
     #[allow(clippy::uninit_vec)]
     fn load_mmap<'a>(
         path: impl AsRef<Path>,
@@ -171,6 +174,9 @@ pub trait Deserialize: TypeHash + ReprHash + DeserializeInner {
     ///
     /// The behavior of `mmap()` can be modified by passing some [`Flags`]; otherwise,
     /// just pass `Flags::empty()`.
+    /// 
+    /// Requires the `mmap` feature.
+    #[cfg(feature = "mmap")]
     #[allow(clippy::uninit_vec)]
     fn mmap<'a>(
         path: impl AsRef<Path>,

--- a/epserde/tests/test_memcase.rs
+++ b/epserde/tests/test_memcase.rs
@@ -23,6 +23,7 @@ struct Data<A> {
 
 type Person = PersonVec<Vec<usize>, Data<Vec<u16>>>;
 
+#[cfg(feature="mmap")]
 #[test]
 fn test_mem_case() {
     // Create a new value to serialize


### PR DESCRIPTION
Adds the `mmap` feature (enabled my default).

Fixes #33 .

- Currently it will not compile without the `std` feature.
- Without the `mmap` feature enabled, the inline tests of the README fail.