### PR TITLE
Fix links in new safety sections

### DIFF
--- a/epserde/src/deser/mod.rs
+++ b/epserde/src/deser/mod.rs
@@ -69,20 +69,20 @@ pub trait Deserialize: DeserializeInner {
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](DeserializeInner).
+    /// See the [trait documentation](Deserialize).
     unsafe fn deserialize_full(backend: &mut impl ReadNoStd) -> Result<Self>;
     /// ε-copy deserialize a structure of this type from the given backend.
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](DeserializeInner).
+    /// See the [trait documentation](Deserialize).
     unsafe fn deserialize_eps(backend: &'_ [u8]) -> Result<Self::DeserType<'_>>;
 
     /// Convenience method to fully deserialize from a file.
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](DeserializeInner).
+    /// See the [trait documentation](Deserialize).
     unsafe fn load_full(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let file = std::fs::File::open(path).map_err(Error::FileOpenError)?;
         let mut buf_reader = BufReader::new(file);
@@ -165,7 +165,7 @@ pub trait Deserialize: DeserializeInner {
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](DeserializeInner).
+    /// See the [trait documentation](Deserialize).
     #[cfg(feature = "mmap")]
     unsafe fn load_mmap<'a>(
         path: impl AsRef<Path>,
@@ -215,7 +215,7 @@ pub trait Deserialize: DeserializeInner {
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](DeserializeInner).
+    /// See the [trait documentation](Deserialize).
     #[cfg(feature = "mmap")]
     unsafe fn mmap<'a>(
         path: impl AsRef<Path>,

--- a/epserde/src/ser/mod.rs
+++ b/epserde/src/ser/mod.rs
@@ -76,7 +76,7 @@ pub trait Serialize {
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](SerializeInner).
+    /// See the [trait documentation](Serialize).
     unsafe fn serialize(&self, backend: &mut impl WriteNoStd) -> Result<usize> {
         let mut write_with_pos = WriterWithPos::new(backend);
         self.serialize_on_field_write(&mut write_with_pos)?;
@@ -91,7 +91,7 @@ pub trait Serialize {
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](SerializeInner).
+    /// See the [trait documentation](Serialize).
     unsafe fn serialize_with_schema(&self, backend: &mut impl WriteNoStd) -> Result<Schema> {
         let mut writer_with_pos = WriterWithPos::new(backend);
         let mut schema_writer = SchemaWriter::new(&mut writer_with_pos);
@@ -103,14 +103,14 @@ pub trait Serialize {
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](SerializeInner).
+    /// See the [trait documentation](Serialize).
     unsafe fn serialize_on_field_write(&self, backend: &mut impl WriteWithNames) -> Result<()>;
 
     /// Convenience method to serialize to a file.
     ///
     /// # Safety
     ///
-    /// See the [trait documentation](SerializeInner).
+    /// See the [trait documentation](Serialize).
     unsafe fn store(&self, path: impl AsRef<Path>) -> Result<()> {
         let file = std::fs::File::create(path).map_err(Error::FileOpenError)?;
         let mut buf_writer = BufWriter::new(file);


### PR DESCRIPTION
Safety is documented on the Deserialize and Serialize traits, not on DeserializeInner and SerializeInner.