### PR TITLE
Replace MemCase's unsound impl of Deref/AsMut with a borrow() method

### DIFF
--- a/epserde/tests/test_memcase.rs
+++ b/epserde/tests/test_memcase.rs
@@ -37,18 +37,21 @@ fn test_mem_case() {
     unsafe { person.store("test.bin").unwrap() };
 
     let res = unsafe { Person::load_mem("test.bin").unwrap() };
+    let res = res.borrow();
     assert_eq!(person.test, res.test);
     assert_eq!(person.a, res.a);
     assert_eq!(person.b.a, res.b.a);
     assert_eq!(person.b.b, res.b.b);
 
     let res = unsafe { Person::load_mmap("test.bin", Flags::empty()).unwrap() };
+    let res = res.borrow();
     assert_eq!(person.test, res.test);
     assert_eq!(person.a, res.a);
     assert_eq!(person.b.a, res.b.a);
     assert_eq!(person.b.b, res.b.b);
 
     let res = unsafe { Person::load_mem("test.bin").unwrap() };
+    let res = res.borrow();
     assert_eq!(person.test, res.test);
     assert_eq!(person.a, res.a);
     assert_eq!(person.b.a, res.b.a);
@@ -61,18 +64,21 @@ fn test_mem_case() {
     assert_eq!(person.b.b, res.b.b);
 
     let res = unsafe { Person::mmap("test.bin", Flags::empty()).unwrap() };
+    let res = res.borrow();
     assert_eq!(person.test, res.test);
     assert_eq!(person.a, res.a);
     assert_eq!(person.b.a, res.b.a);
     assert_eq!(person.b.b, res.b.b);
 
     let res = unsafe { Person::mmap("test.bin", Flags::TRANSPARENT_HUGE_PAGES).unwrap() };
+    let res = res.borrow();
     assert_eq!(person.test, res.test);
     assert_eq!(person.a, res.a);
     assert_eq!(person.b.a, res.b.a);
     assert_eq!(person.b.b, res.b.b);
 
     let res = unsafe { Person::mmap("test.bin", Flags::empty()).unwrap() };
+    let res = res.borrow();
     assert_eq!(person.test, res.test);
     assert_eq!(person.a, res.a);
     assert_eq!(person.b.a, res.b.a);


### PR DESCRIPTION
This code compiled fine, but raised a segfault on the last println:

```rust
use epserde::deser::Deserialize;
use epserde::prelude::Flags;
use epserde::prelude::MemCase;
use epserde::ser::Serialize;
use std::fs::File;
use std::io::BufWriter;

fn main() {
    let v = vec![0u64, 10, 20, 30, 40];

    let path = std::path::PathBuf::from("/tmp/test.vector");

    println!("Writing vector...");
    let mut writer = BufWriter::new(File::create(&path).expect("Could not create temp file"));
    unsafe { v.serialize(&mut writer) }.expect("Could not write vector");
    drop(v);

    println!("mmapping vector...");
    let v =
        unsafe { <Vec<u64>>::mmap(&path, Flags::RANDOM_ACCESS) }.expect("Could not mmap vector");
    let v2: &[u64] = *v;

    println!("Vector value:");
    println!("{:?}", v2);

    println!("Dropping vector...");
    drop(v);

    println!("Vector value:");
    println!("{:?}", v2);
}
```

This is because the `Deref` implementation of `MemCase<&[u64]>` effectively yields a `&&'static [u64]` which can itself be dereferenced to a `&'static [u64]`, which outlives the `MemCase`.

There does not seem to be a way to implement `Deref` or `AsRef` (or `std::borrow::Borrow`) without yielding some sort of `'static` here. So as far as I can tell, we have to take this ergonomic blow in order to avoid segfaults that are very easy for users to trigger unknowingly.

Resolves https://github.com/vigna/epserde-rs/issues/54