### PR TITLE
refactor: Remove unsafe from DeserializeInner trait

### DIFF
--- a/epserde-derive/src/lib.rs
+++ b/epserde-derive/src/lib.rs
@@ -486,7 +486,7 @@ pub fn epserde_derive(input: TokenStream) -> TokenStream {
 
                     // SAFETY: &'epserde_desertype Self is covariant
                     #[automatically_derived]
-                    unsafe impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des
+                    impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des
                     {
                         unsafe fn _deserialize_full_inner(
                             backend: &mut impl epserde::deser::ReadWithPos,
@@ -543,7 +543,7 @@ pub fn epserde_derive(input: TokenStream) -> TokenStream {
 
                     // SAFETY: #name is a struct, so it is covariant
                     #[automatically_derived]
-                    unsafe impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des {
+                    impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des {
                         unsafe fn _deserialize_full_inner(
                             backend: &mut impl epserde::deser::ReadWithPos,
                         ) -> core::result::Result<Self, epserde::deser::Error> {
@@ -828,7 +828,7 @@ pub fn epserde_derive(input: TokenStream) -> TokenStream {
 
                     // SAFETY: &'epserde_desertype Self is covariant
                     #[automatically_derived]
-                    unsafe impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des {
+                    impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des {
                         unsafe fn _deserialize_full_inner(
                             backend: &mut impl epserde::deser::ReadWithPos,
                         ) -> core::result::Result<Self, epserde::deser::Error> {
@@ -883,7 +883,7 @@ pub fn epserde_derive(input: TokenStream) -> TokenStream {
                     }
                     // SAFETY: #name is an enum, so it is covariant
                     #[automatically_derived]
-                    unsafe impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des {
+                    impl<#generics_deserialize> epserde::deser::DeserializeInner for #name<#concat_generics> #where_clause_des {
                         unsafe fn _deserialize_full_inner(
                             backend: &mut impl epserde::deser::ReadWithPos,
                         ) -> core::result::Result<Self, epserde::deser::Error> {

--- a/epserde/src/deser/mod.rs
+++ b/epserde/src/deser/mod.rs
@@ -341,7 +341,7 @@ pub trait Deserialize: DeserializeInner {
 /// # Safety
 ///
 /// See [`Deserialize`].
-pub unsafe trait DeserializeInner: Sized {
+pub trait DeserializeInner: Sized {
     /// The deserialization type associated with this type. It can be retrieved
     /// conveniently with the alias [`DeserType`].
     type DeserType<'a>;

--- a/epserde/src/impls/array.rs
+++ b/epserde/src/impls/array.rs
@@ -75,7 +75,7 @@ impl<T: DeepCopy + SerializeInner, const N: usize> SerializeHelper<Deep> for [T;
     }
 }
 
-unsafe impl<T: CopyType + DeserializeInner, const N: usize> DeserializeInner for [T; N]
+impl<T: CopyType + DeserializeInner, const N: usize> DeserializeInner for [T; N]
 where
     [T; N]: DeserializeHelper<<T as CopyType>::Copy, FullType = [T; N]>,
 {

--- a/epserde/src/impls/boxed_slice.rs
+++ b/epserde/src/impls/boxed_slice.rs
@@ -60,7 +60,7 @@ impl<T: DeepCopy + SerializeInner> SerializeHelper<Deep> for Box<[T]> {
 }
 
 // This delegates to a private helper trait which we can specialize on in stable rust
-unsafe impl<T: DeserializeInner + CopyType> DeserializeInner for Box<[T]>
+impl<T: DeserializeInner + CopyType> DeserializeInner for Box<[T]>
 where
     Box<[T]>: DeserializeHelper<<T as CopyType>::Copy, FullType = Box<[T]>>,
 {

--- a/epserde/src/impls/prim.rs
+++ b/epserde/src/impls/prim.rs
@@ -67,7 +67,7 @@ macro_rules! impl_prim_ser_des {
             }
         }
 
-		unsafe impl DeserializeInner for $ty {
+		impl DeserializeInner for $ty {
             #[inline(always)]
             unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<$ty> {
                 let mut buf = [0; size_of::<$ty>()];
@@ -109,7 +109,7 @@ macro_rules! impl_nonzero_ser_des {
             }
         }
 
-		unsafe impl DeserializeInner for $ty {
+		impl DeserializeInner for $ty {
             #[inline(always)]
             unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<$ty> {
                 let mut buf = [0; size_of::<$ty>()];
@@ -179,7 +179,7 @@ impl SerializeInner for bool {
     }
 }
 
-unsafe impl DeserializeInner for bool {
+impl DeserializeInner for bool {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<bool> {
         Ok(u8::_deserialize_full_inner(backend)? != 0)
@@ -208,7 +208,7 @@ impl SerializeInner for char {
     }
 }
 
-unsafe impl DeserializeInner for char {
+impl DeserializeInner for char {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         Ok(char::from_u32(u32::_deserialize_full_inner(backend)?).unwrap())
@@ -235,7 +235,7 @@ impl SerializeInner for () {
     }
 }
 
-unsafe impl DeserializeInner for () {
+impl DeserializeInner for () {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(_backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         Ok(())
@@ -288,7 +288,7 @@ impl<T: ?Sized> SerializeInner for PhantomData<T> {
     }
 }
 
-unsafe impl<T: ?Sized> DeserializeInner for PhantomData<T> {
+impl<T: ?Sized> DeserializeInner for PhantomData<T> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(_backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         Ok(PhantomData::<T>)
@@ -339,7 +339,7 @@ impl<T: SerializeInner + TypeHash + AlignHash> SerializeInner for Option<T> {
     }
 }
 
-unsafe impl<T: DeserializeInner> DeserializeInner for Option<T> {
+impl<T: DeserializeInner> DeserializeInner for Option<T> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let tag = u8::_deserialize_full_inner(backend)?;

--- a/epserde/src/impls/stdlib.rs
+++ b/epserde/src/impls/stdlib.rs
@@ -94,7 +94,7 @@ impl<Idx: ZeroCopy + SerializeInner + TypeHash + AlignHash> SerializeInner
     }
 }
 
-unsafe impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::Range<Idx> {
+impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::Range<Idx> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let start = Idx::_deserialize_full_inner(backend)?;
@@ -126,7 +126,7 @@ impl<Idx: ZeroCopy + SerializeInner + TypeHash + AlignHash> SerializeInner
     }
 }
 
-unsafe impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::RangeFrom<Idx> {
+impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::RangeFrom<Idx> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let start = Idx::_deserialize_full_inner(backend)?;
@@ -158,7 +158,7 @@ impl<Idx: ZeroCopy + SerializeInner + TypeHash + AlignHash> SerializeInner
     }
 }
 
-unsafe impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::RangeInclusive<Idx> {
+impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::RangeInclusive<Idx> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let start = Idx::_deserialize_full_inner(backend)?;
@@ -194,7 +194,7 @@ impl<Idx: ZeroCopy + SerializeInner + TypeHash + AlignHash> SerializeInner
     }
 }
 
-unsafe impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::RangeTo<Idx> {
+impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner for core::ops::RangeTo<Idx> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let end = Idx::_deserialize_full_inner(backend)?;
@@ -224,7 +224,7 @@ impl<Idx: ZeroCopy + SerializeInner + TypeHash + AlignHash> SerializeInner
     }
 }
 
-unsafe impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner
+impl<Idx: ZeroCopy + DeserializeInner> DeserializeInner
     for core::ops::RangeToInclusive<Idx>
 {
     #[inline(always)]
@@ -253,7 +253,7 @@ impl SerializeInner for core::ops::RangeFull {
     }
 }
 
-unsafe impl DeserializeInner for core::ops::RangeFull {
+impl DeserializeInner for core::ops::RangeFull {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(_backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         Ok(core::ops::RangeFull)
@@ -303,7 +303,7 @@ impl<T: SerializeInner + TypeHash + AlignHash> SerializeInner for core::ops::Bou
     }
 }
 
-unsafe impl<T: DeserializeInner> DeserializeInner for core::ops::Bound<T> {
+impl<T: DeserializeInner> DeserializeInner for core::ops::Bound<T> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let tag = u8::_deserialize_full_inner(backend)?;
@@ -378,7 +378,7 @@ impl<B: SerializeInner + TypeHash + AlignHash, C: SerializeInner + TypeHash + Al
     }
 }
 
-unsafe impl<B: DeserializeInner, C: DeserializeInner> DeserializeInner
+impl<B: DeserializeInner, C: DeserializeInner> DeserializeInner
     for core::ops::ControlFlow<B, C>
 {
     #[inline(always)]

--- a/epserde/src/impls/string.rs
+++ b/epserde/src/impls/string.rs
@@ -65,7 +65,7 @@ impl SerializeInner for String {
     }
 }
 
-unsafe impl DeserializeInner for String {
+impl DeserializeInner for String {
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         let slice = deserialize_full_vec_zero(backend)?;
         Ok(String::from_utf8(slice).unwrap())
@@ -99,7 +99,7 @@ impl SerializeInner for Box<str> {
     }
 }
 
-unsafe impl DeserializeInner for Box<str> {
+impl DeserializeInner for Box<str> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         Ok(String::_deserialize_full_inner(backend)?.into_boxed_str())

--- a/epserde/src/impls/tuple.rs
+++ b/epserde/src/impls/tuple.rs
@@ -87,7 +87,7 @@ macro_rules! impl_tuples {
             }
         }
 
-		unsafe impl<T: ZeroCopy + TypeHash + AlignHash> DeserializeInner for ($($t,)*) {
+		impl<T: ZeroCopy + TypeHash + AlignHash> DeserializeInner for ($($t,)*) {
             type DeserType<'a> = &'a ($($t,)*);
             unsafe fn _deserialize_full_inner(backend: &mut impl ReadWithPos) -> deser::Result<Self> {
                 deserialize_full_zero::<($($t,)*)>(backend)

--- a/epserde/src/impls/vec.rs
+++ b/epserde/src/impls/vec.rs
@@ -66,7 +66,7 @@ impl<T: DeepCopy + SerializeInner> SerializeHelper<Deep> for Vec<T> {
 }
 
 // This delegates to a private helper trait which we can specialize on in stable rust
-unsafe impl<T: CopyType + DeserializeInner> DeserializeInner for Vec<T>
+impl<T: CopyType + DeserializeInner> DeserializeInner for Vec<T>
 where
     Vec<T>: DeserializeHelper<<T as CopyType>::Copy, FullType = Vec<T>>,
 {

--- a/epserde/src/lib.rs
+++ b/epserde/src/lib.rs
@@ -155,7 +155,7 @@ impl<T: ?Sized> SerializeInner for PhantomDeserData<T> {
     }
 }
 
-unsafe impl<T: DeserializeInner> DeserializeInner for PhantomDeserData<T> {
+impl<T: DeserializeInner> DeserializeInner for PhantomDeserData<T> {
     #[inline(always)]
     unsafe fn _deserialize_full_inner(_backend: &mut impl ReadWithPos) -> deser::Result<Self> {
         Ok(PhantomDeserData(PhantomData))

--- a/epserde/tests/fail/drop_memcase.stderr
+++ b/epserde/tests/fail/drop_memcase.stderr
@@ -1,0 +1,11 @@
+error[E0505]: cannot move out of `mem_case` because it is borrowed
+  --> tests/fail/drop_memcase.rs:18:10
+   |
+16 |     let mem_case = unsafe { Vec::<i32>::read_mem(cursor, buffer.len()).unwrap() };
+   |         -------- binding `mem_case` declared here
+17 |     let v = mem_case.uncase();
+   |             -------- borrow of `mem_case` occurs here
+18 |     drop(mem_case);
+   |          ^^^^^^^^ move out of `mem_case` occurs here
+19 |     let _vv = v;
+   |               - borrow later used here

--- a/test_output.log
+++ b/test_output.log
@@ -1,0 +1,57 @@
+   Compiling epserde-derive v0.8.0 (/app/epserde-derive)
+   Compiling epserde v0.8.0 (/app/epserde)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 7.81s
+     Running unittests src/lib.rs (target/debug/deps/epserde-4cba48141556447f)
+
+running 2 tests
+test test_pad_align_to ... ok
+test utils::aligned_cursor::tests::test_aligned_cursor ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/fail.rs (target/debug/deps/fail-edbbab370a46376a)
+
+running 1 test
+   Compiling epserde-derive v0.8.0 (/app/epserde-derive)
+    Checking epserde v0.8.0 (/app/epserde)
+    Checking epserde-tests v0.0.0 (/app/target/tests/trybuild/epserde)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.46s
+
+
+test [0m[1mtests/fail/drop_memcase.rs[0m ... [0m[1m[33mwip
+[0m[1m[33m
+[0m[1m[33mNOTE[0m: writing the following output to `wip/drop_memcase.stderr`.
+Move this file to `tests/fail/drop_memcase.stderr` to accept it as correct.
+[0m[33m┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+[0m[33merror[E0505]: cannot move out of `mem_case` because it is borrowed
+[0m[33m  --> tests/fail/drop_memcase.rs:18:10
+[0m[33m   |
+[0m[33m16 |     let mem_case = unsafe { Vec::<i32>::read_mem(cursor, buffer.len()).unwrap() };
+[0m[33m   |         -------- binding `mem_case` declared here
+[0m[33m17 |     let v = mem_case.uncase();
+[0m[33m   |             -------- borrow of `mem_case` occurs here
+[0m[33m18 |     drop(mem_case);
+[0m[33m   |          ^^^^^^^^ move out of `mem_case` occurs here
+[0m[33m19 |     let _vv = v;
+[0m[33m   |               - borrow later used here
+[0m[33m┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+[0m
+
+
+test fail ... FAILED
+
+failures:
+
+---- fail stdout ----
+
+thread 'fail' panicked at /home/jules/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trybuild-1.0.110/src/run.rs:105:13:
+successfully created new stderr files for 1 test cases
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    fail
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.71s
+
+error: test failed, to rerun pass `-p epserde --test fail`


### PR DESCRIPTION
The `unsafe` qualifier has been removed from the `DeserializeInner` trait definition. This change makes the trait itself safe to implement, while the methods within the trait remain `unsafe`.

All implementations of `DeserializeInner` have been updated to remove the `unsafe` keyword, including the code generated by the `Epserde` derive macro.

The `trybuild` test outputs have been updated to reflect these changes.