### PR TITLE
Refactor: Replace chained if let with nested if

### DIFF
--- a/epserde-derive/src/lib.rs
+++ b/epserde-derive/src/lib.rs
@@ -74,9 +74,10 @@ fn get_ident(ty: &syn::Type) -> Option<&syn::Ident> {
             segments,
         },
     }) = ty
-        && segments.len() == 1
     {
-        return Some(&segments[0].ident);
+        if segments.len() == 1 {
+            return Some(&segments[0].ident);
+        }
     }
 
     None
@@ -106,10 +107,11 @@ fn gen_deser_method_call(
     {
         // This is a pretty weak check, as a user could define its own PhantomDeserData,
         // but it should be good enough in practice
-        if let Some(segment) = segments.last()
-            && segment.ident == "PhantomDeserData"
-        {
-            return syn::parse_quote!(#field_name: unsafe { <#field_type>::_deserialize_eps_inner_special(backend)? });
+        if let Some(segment) = segments.last() {
+            if segment.ident == "PhantomDeserData"
+            {
+                return syn::parse_quote!(#field_name: unsafe { <#field_type>::_deserialize_eps_inner_special(backend)? });
+            }
         }
 
         // If it's just an identifier that is among the type parameters that
@@ -419,10 +421,11 @@ fn gen_epserde_struct_impl(ctx: &EpserdeContext, s: &syn::DataStruct) -> proc_ma
         let field_type = &field.ty;
 
         // We look for type parameters that are types of fields
-        if let Some(field_type_id) = get_ident(field_type)
-            && ctx.type_params.contains(field_type_id)
-        {
-            field_type_params.insert(field_type_id);
+        if let Some(field_type_id) = get_ident(field_type) {
+            if ctx.type_params.contains(field_type_id)
+            {
+                field_type_params.insert(field_type_id);
+            }
         }
 
         method_calls.push(gen_deser_method_call(
@@ -601,10 +604,11 @@ fn gen_epserde_enum_impl(ctx: &EpserdeContext, e: &syn::DataEnum) -> proc_macro2
                     let field_type = &field.ty;
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type)
-                        && ctx.type_params.contains(field_type_id)
-                    {
-                        all_field_type_params.insert(field_type_id);
+                    if let Some(field_type_id) = get_ident(field_type) {
+                        if ctx.type_params.contains(field_type_id)
+                        {
+                            all_field_type_params.insert(field_type_id);
+                        }
                     }
 
                     method_calls.push(gen_deser_method_call(
@@ -653,10 +657,11 @@ fn gen_epserde_enum_impl(ctx: &EpserdeContext, e: &syn::DataEnum) -> proc_macro2
                     let field_type = &field.ty;
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type)
-                        && ctx.type_params.contains(field_type_id)
-                    {
-                        all_field_type_params.insert(field_type_id);
+                    if let Some(field_type_id) = get_ident(field_type) {
+                        if ctx.type_params.contains(field_type_id)
+                        {
+                            all_field_type_params.insert(field_type_id);
+                        }
                     }
 
                     field_indices.push(
@@ -1128,10 +1133,11 @@ fn gen_struct_type_info_impl(
         field_types.push(field_type);
 
         // We look for type parameters that are types of fields
-        if let Some(field_type_id) = get_ident(field_type)
-            && ctx.type_params.contains(field_type_id)
-        {
-            field_type_params.insert(field_type_id);
+        if let Some(field_type_id) = get_ident(field_type) {
+            if ctx.type_params.contains(field_type_id)
+            {
+                field_type_params.insert(field_type_id);
+            }
         }
     }
 
@@ -1208,10 +1214,11 @@ fn gen_enum_type_info_impl(ctx: TypeInfoContext, e: &syn::DataEnum) -> proc_macr
                     }]);
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type)
-                        && ctx.type_params.contains(field_type_id)
-                    {
-                        all_field_type_params.push(field_type);
+                    if let Some(field_type_id) = get_ident(field_type) {
+                        if ctx.type_params.contains(field_type_id)
+                        {
+                            all_field_type_params.push(field_type);
+                        }
                     }
                 }
             }
@@ -1237,10 +1244,11 @@ fn gen_enum_type_info_impl(ctx: TypeInfoContext, e: &syn::DataEnum) -> proc_macr
                     }]);
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type)
-                        && ctx.type_params.contains(field_type_id)
-                    {
-                        all_field_type_params.push(field_type);
+                    if let Some(field_type_id) = get_ident(field_type) {
+                        if ctx.type_params.contains(field_type_id)
+                        {
+                            all_field_type_params.push(field_type);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The derive code in epserde-derive contained several chained "if let" statements, which are available only since Rust 1.89.

This commit converts them to a nested "if" statement inside the "if let" block, so the code is compatible with Rust 1.85.