### PR TITLE
Refactor: Unify test return types to anyhow::Result<()>

### DIFF
--- a/epserde-derive/src/lib.rs
+++ b/epserde-derive/src/lib.rs
@@ -74,10 +74,9 @@ fn get_ident(ty: &syn::Type) -> Option<&syn::Ident> {
             segments,
         },
     }) = ty
+        && segments.len() == 1
     {
-        if segments.len() == 1 {
-            return Some(&segments[0].ident);
-        }
+        return Some(&segments[0].ident);
     }
 
     None
@@ -107,11 +106,10 @@ fn gen_deser_method_call(
     {
         // This is a pretty weak check, as a user could define its own PhantomDeserData,
         // but it should be good enough in practice
-        if let Some(segment) = segments.last() {
-            if segment.ident == "PhantomDeserData"
-            {
-                return syn::parse_quote!(#field_name: unsafe { <#field_type>::_deserialize_eps_inner_special(backend)? });
-            }
+        if let Some(segment) = segments.last()
+            && segment.ident == "PhantomDeserData"
+        {
+            return syn::parse_quote!(#field_name: unsafe { <#field_type>::_deserialize_eps_inner_special(backend)? });
         }
 
         // If it's just an identifier that is among the type parameters that
@@ -421,11 +419,10 @@ fn gen_epserde_struct_impl(ctx: &EpserdeContext, s: &syn::DataStruct) -> proc_ma
         let field_type = &field.ty;
 
         // We look for type parameters that are types of fields
-        if let Some(field_type_id) = get_ident(field_type) {
-            if ctx.type_params.contains(field_type_id)
-            {
-                field_type_params.insert(field_type_id);
-            }
+        if let Some(field_type_id) = get_ident(field_type)
+            && ctx.type_params.contains(field_type_id)
+        {
+            field_type_params.insert(field_type_id);
         }
 
         method_calls.push(gen_deser_method_call(
@@ -604,11 +601,10 @@ fn gen_epserde_enum_impl(ctx: &EpserdeContext, e: &syn::DataEnum) -> proc_macro2
                     let field_type = &field.ty;
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type) {
-                        if ctx.type_params.contains(field_type_id)
-                        {
-                            all_field_type_params.insert(field_type_id);
-                        }
+                    if let Some(field_type_id) = get_ident(field_type)
+                        && ctx.type_params.contains(field_type_id)
+                    {
+                        all_field_type_params.insert(field_type_id);
                     }
 
                     method_calls.push(gen_deser_method_call(
@@ -657,11 +653,10 @@ fn gen_epserde_enum_impl(ctx: &EpserdeContext, e: &syn::DataEnum) -> proc_macro2
                     let field_type = &field.ty;
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type) {
-                        if ctx.type_params.contains(field_type_id)
-                        {
-                            all_field_type_params.insert(field_type_id);
-                        }
+                    if let Some(field_type_id) = get_ident(field_type)
+                        && ctx.type_params.contains(field_type_id)
+                    {
+                        all_field_type_params.insert(field_type_id);
                     }
 
                     field_indices.push(
@@ -1133,11 +1128,10 @@ fn gen_struct_type_info_impl(
         field_types.push(field_type);
 
         // We look for type parameters that are types of fields
-        if let Some(field_type_id) = get_ident(field_type) {
-            if ctx.type_params.contains(field_type_id)
-            {
-                field_type_params.insert(field_type_id);
-            }
+        if let Some(field_type_id) = get_ident(field_type)
+            && ctx.type_params.contains(field_type_id)
+        {
+            field_type_params.insert(field_type_id);
         }
     }
 
@@ -1214,11 +1208,10 @@ fn gen_enum_type_info_impl(ctx: TypeInfoContext, e: &syn::DataEnum) -> proc_macr
                     }]);
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type) {
-                        if ctx.type_params.contains(field_type_id)
-                        {
-                            all_field_type_params.push(field_type);
-                        }
+                    if let Some(field_type_id) = get_ident(field_type)
+                        && ctx.type_params.contains(field_type_id)
+                    {
+                        all_field_type_params.push(field_type);
                     }
                 }
             }
@@ -1244,11 +1237,10 @@ fn gen_enum_type_info_impl(ctx: TypeInfoContext, e: &syn::DataEnum) -> proc_macr
                     }]);
 
                     // We look for type parameters that are types of fields
-                    if let Some(field_type_id) = get_ident(field_type) {
-                        if ctx.type_params.contains(field_type_id)
-                        {
-                            all_field_type_params.push(field_type);
-                        }
+                    if let Some(field_type_id) = get_ident(field_type)
+                        && ctx.type_params.contains(field_type_id)
+                    {
+                        all_field_type_params.push(field_type);
                     }
                 }
             }

--- a/epserde/tests/fail.rs
+++ b/epserde/tests/fail.rs
@@ -1,5 +1,8 @@
+use anyhow::Result;
+
 #[test]
-fn fail() {
+fn fail() -> Result<()> {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/fail/*.rs");
+    Ok(())
 }

--- a/epserde/tests/test_max_size_of.rs
+++ b/epserde/tests/test_max_size_of.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+use anyhow::Result;
 use epserde::prelude::*;
 use maligned::{A16, A64};
 #[derive(Epserde, Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,27 +33,27 @@ struct MyStruct {
 
 #[test]
 /// Check that we don't have any collision on most types
-fn test_max_size_of_align() {
+fn test_max_size_of_align() -> Result<()> {
     assert_eq!(64, MyStruct64::max_size_of());
     assert_eq!(MyStruct::max_size_of(), MyStruct2::max_size_of());
 
     let x = MyStruct { u: 0x89 };
     let mut cursor = <AlignedCursor<A16>>::new();
     // Serialize
-    let _bytes_written = unsafe { x.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { x.serialize(&mut cursor)? };
 
     // Do an ε-copy deserialization
-    let eps = unsafe { <MyStruct>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <MyStruct>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(x, *eps);
 
     // Create a new value to serialize
     let x = MyStruct2 { u: 0x89 };
     let mut cursor = <AlignedCursor<A16>>::new();
     // Serialize
-    let _bytes_written = unsafe { x.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { x.serialize(&mut cursor)? };
 
     // Do an ε-copy deserialization
-    let eps = unsafe { <MyStruct2>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <MyStruct2>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(x, *eps);
 
     // Create a new value to serialize
@@ -60,9 +61,10 @@ fn test_max_size_of_align() {
     // We need a higher alignment
     let mut cursor = <AlignedCursor<A64>>::new();
     // Serialize
-    let _bytes_written = unsafe { x.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { x.serialize(&mut cursor)? };
 
     // Do an ε-copy deserialization
-    let eps = unsafe { <MyStruct64>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <MyStruct64>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(x, *eps);
+    Ok(())
 }

--- a/epserde/tests/test_regression.rs
+++ b/epserde/tests/test_regression.rs
@@ -7,6 +7,7 @@
 use epserde::prelude::*;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
+use anyhow::Result;
 
 fn get_type_hash<T: TypeHash + ?Sized>() -> u64 {
     let mut hasher = DefaultHasher::new();
@@ -22,7 +23,7 @@ fn get_align_hash<T: AlignHash + ?Sized>() -> u64 {
 }
 
 #[test]
-fn test_primitive_types() {
+fn test_primitive_types() -> Result<()> {
     assert_eq!(get_type_hash::<isize>(), 0xad77ef2a0c071b87);
     assert_eq!(get_align_hash::<isize>(), 0xd3eed631c35c21cf);
     assert_eq!(get_type_hash::<i8>(), 0x1bb527fe1af58754);
@@ -57,57 +58,65 @@ fn test_primitive_types() {
     assert_eq!(get_align_hash::<char>(), 0x6881f435bc0ca85f);
     assert_eq!(get_type_hash::<()>(), 0x2439715d39cd513);
     assert_eq!(get_align_hash::<()>(), 0x76be999e3e25b2a0);
+    Ok(())
 }
 
 #[test]
-fn test_option() {
+fn test_option() -> Result<()> {
     assert_eq!(get_type_hash::<Option<i32>>(), 0x36d9437e00a00833);
     assert_eq!(get_align_hash::<Option<i32>>(), 0x6881f435bc0ca85f);
+    Ok(())
 }
 
 #[test]
-fn test_string_types() {
+fn test_string_types() -> Result<()> {
     assert_eq!(get_type_hash::<String>(), 0xe4297f5be0f5dd50);
     assert_eq!(get_align_hash::<String>(), 0xd1fba762150c532c);
     assert_eq!(get_type_hash::<Box<str>>(), 0x19aa1d67f7ad7a3e);
     assert_eq!(get_align_hash::<Box<str>>(), 0xd1fba762150c532c);
     assert_eq!(get_type_hash::<str>(), 0x393e833de113cd8c);
+    Ok(())
 }
 
 #[test]
-fn test_array_types() {
+fn test_array_types() -> Result<()> {
     assert_eq!(get_type_hash::<[i32; 5]>(), 0xff020632241e51b0);
     assert_eq!(get_align_hash::<[i32; 5]>(), 0x6881f435bc0ca85f);
+    Ok(())
 }
 
 #[test]
-fn test_slice_types() {
+fn test_slice_types() -> Result<()> {
     assert_eq!(get_type_hash::<&[i32]>(), 0x117f4821c6983671);
     assert_eq!(get_align_hash::<&[i32]>(), 0x6881f435bc0ca85f);
     assert_eq!(get_type_hash::<[i32]>(), 0xe053d268c8ad5c04);
+    Ok(())
 }
 
 #[test]
-fn test_boxed_slice_types() {
+fn test_boxed_slice_types() -> Result<()> {
     assert_eq!(get_type_hash::<Box<[i32]>>(), 0x400f9211e94c1834);
     assert_eq!(get_align_hash::<Box<[i32]>>(), 0x6881f435bc0ca85f);
+    Ok(())
 }
 
 #[test]
-fn test_tuple_types() {
+fn test_tuple_types() -> Result<()> {
     assert_eq!(get_type_hash::<(i32,)>(), 0x4c6eb7a52a31e7b9);
     assert_eq!(get_align_hash::<(i32,)>(), 0x6881f435bc0ca85f);
     assert_eq!(get_type_hash::<(i32, f64)>(), 0x6c1bf8932e12dc1);
+    Ok(())
 }
 
 #[test]
-fn test_vec_types() {
+fn test_vec_types() -> Result<()> {
     assert_eq!(get_type_hash::<Vec<i32>>(), 0x117f4821c6983671);
     assert_eq!(get_align_hash::<Vec<i32>>(), 0x6881f435bc0ca85f);
+    Ok(())
 }
 
 #[test]
-fn test_stdlib_types() {
+fn test_stdlib_types() -> Result<()> {
     use core::ops::{
         Bound, ControlFlow, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
     };
@@ -135,6 +144,7 @@ fn test_stdlib_types() {
         get_align_hash::<ControlFlow<i32, f64>>(),
         0xc3caaeef7aa4605a
     );
+    Ok(())
 }
 
 #[derive(Epserde, Debug, PartialEq)]
@@ -173,40 +183,45 @@ struct MyStructConstThenType<const N: usize, T: PartialEq> {
 }
 
 #[test]
-fn test_derive_struct() {
+fn test_derive_struct() -> Result<()> {
     assert_eq!(get_type_hash::<MyStruct>(), 0x65125c7b120befff);
     assert_eq!(get_align_hash::<MyStruct>(), 0xc3caaeef7aa4605a);
+    Ok(())
 }
 
 #[test]
-fn test_derive_struct_generic() {
+fn test_derive_struct_generic() -> Result<()> {
     assert_eq!(get_type_hash::<MyStructGeneric<i32>>(), 0x6dced006dd1acb8f);
     assert_eq!(get_align_hash::<MyStructGeneric<i32>>(), 0x6881f435bc0ca85f);
+    Ok(())
 }
 
 #[test]
-fn test_derive_enum() {
+fn test_derive_enum() -> Result<()> {
     assert_eq!(get_type_hash::<MyEnum>(), 0xf5e19aa69f2d9fac);
     assert_eq!(get_align_hash::<MyEnum>(), 0x7c4ea1189a62724c);
+    Ok(())
 }
 
 #[test]
-fn test_derive_struct_const() {
+fn test_derive_struct_const() -> Result<()> {
     assert_eq!(get_type_hash::<MyStructConst<5>>(), 0x87c97042d431cbf7);
     assert_eq!(get_align_hash::<MyStructConst<5>>(), 0x6881f435bc0ca85f);
+    Ok(())
 }
 
 #[test]
-fn test_derive_struct_mixed() {
+fn test_derive_struct_mixed() -> Result<()> {
     assert_eq!(get_type_hash::<MyStructMixed<i32, 5>>(), 0xa8a943379dbe6ea7);
     assert_eq!(
         get_align_hash::<MyStructMixed<i32, 5>>(),
         0xde0fd80637b3a4da
     );
+    Ok(())
 }
 
 #[test]
-fn test_derive_struct_const_then_type() {
+fn test_derive_struct_const_then_type() -> Result<()> {
     assert_eq!(
         get_type_hash::<MyStructConstThenType<5, i32>>(),
         0xba025cd70e024ad5
@@ -215,4 +230,5 @@ fn test_derive_struct_const_then_type() {
         get_align_hash::<MyStructConstThenType<5, i32>>(),
         0xde0fd80637b3a4da
     );
+    Ok(())
 }

--- a/epserde/tests/test_std.rs
+++ b/epserde/tests/test_std.rs
@@ -8,8 +8,9 @@
 use epserde::prelude::*;
 use maligned::A16;
 use std::{rc::Rc, sync::Arc};
+use anyhow::Result;
 
-fn test_generic<T>(s: T) -> Result<(), Box<dyn std::error::Error>>
+fn test_generic<T>(s: T) -> Result<()>
 where
     T: Serialize + Deserialize + PartialEq + core::fmt::Debug,
     for<'a> <T as DeserializeInner>::DeserType<'a>: PartialEq<T> + core::fmt::Debug,
@@ -20,7 +21,7 @@ where
 fn test_generic_split<Ser, Deser, OwnedSer>(
     s: Ser,
     deref: impl Fn(&Ser) -> &OwnedSer,
-) -> Result<(), Box<dyn std::error::Error>>
+) -> Result<()>
 where
     Ser: Serialize,
     Deser: Deserialize + PartialEq<OwnedSer> + core::fmt::Debug,
@@ -61,7 +62,7 @@ where
 }
 
 #[test]
-fn test_containers() -> Result<(), Box<dyn std::error::Error>> {
+fn test_containers() -> Result<()> {
     test_generic::<Box<i32>>(Box::new(10))?;
     test_generic::<Arc<i32>>(Arc::new(10))?;
     test_generic::<Rc<i32>>(Rc::new(10))?;
@@ -69,14 +70,14 @@ fn test_containers() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_references() -> Result<(), Box<dyn std::error::Error>> {
+fn test_references() -> Result<()> {
     test_generic_split::<&i32, i32, i32>(&10, |n| *n)?;
     test_generic_split::<&mut i32, i32, i32>(&mut 10, |n| *n)?;
     Ok(())
 }
 
 #[test]
-fn test_erasure_vec() -> Result<(), Box<dyn std::error::Error>> {
+fn test_erasure_vec() -> Result<()> {
     let data = vec![1, 2, 3];
     let mut cursor = <AlignedCursor<A16>>::new();
     unsafe { data.serialize(&mut cursor)? };
@@ -129,7 +130,7 @@ fn test_erasure_vec() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_erasure_struct() -> Result<(), Box<dyn std::error::Error>> {
+fn test_erasure_struct() -> Result<()> {
     #[derive(Epserde, PartialEq, Eq, Debug)]
     struct Data<A>(A);
     let data = Data(vec![1, 2, 3]);

--- a/epserde/tests/test_tuples.rs
+++ b/epserde/tests/test_tuples.rs
@@ -6,29 +6,30 @@
 
 use epserde::prelude::*;
 use maligned::A16;
+use anyhow::Result;
 
 macro_rules! impl_test {
     ($ty:ty, $data:expr) => {{
         let mut cursor = <AlignedCursor<A16>>::new();
 
-        let _ = unsafe { $data.serialize_with_schema(&mut cursor).unwrap() };
+        let _ = unsafe { $data.serialize_with_schema(&mut cursor)? };
 
         cursor.set_position(0);
-        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor).unwrap() };
+        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor)? };
         assert_eq!($data, full_copy);
 
-        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes()).unwrap() };
+        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes())? };
         assert_eq!($data, *eps_copy);
     }
     {
         let mut cursor = <AlignedCursor<A16>>::new();
-        unsafe { $data.serialize(&mut cursor).unwrap() };
+        unsafe { $data.serialize(&mut cursor)? };
 
         cursor.set_position(0);
-        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor).unwrap() };
+        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor)? };
         assert_eq!($data, full_copy);
 
-        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes()).unwrap() };
+        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes())? };
         assert_eq!($data, *eps_copy);
     }};
 }
@@ -36,8 +37,9 @@ macro_rules! impl_test {
 macro_rules! test_zero {
     ($test_name:ident, $ty:ty, $data: expr) => {
         #[test]
-        fn $test_name() {
+        fn $test_name() -> Result<()> {
             impl_test!($ty, $data);
+            Ok(())
         }
     };
 }

--- a/epserde/tests/test_type_hash_val.rs
+++ b/epserde/tests/test_type_hash_val.rs
@@ -8,6 +8,8 @@ use core::hash::Hasher;
 use epserde::traits::TypeHash;
 use std::collections::HashMap;
 use xxhash_rust::xxh3::{Xxh3, Xxh3Builder};
+use anyhow::Result;
+
 macro_rules! impl_test {
     ($hashes:expr, $value:expr) => {{
         let mut hasher = Xxh3::with_seed(0);
@@ -25,7 +27,7 @@ macro_rules! impl_test {
 
 #[test]
 /// Check that we don't have any collision on most types
-fn test_type_hash_collision() {
+fn test_type_hash_collision() -> Result<()> {
     let mut hashes = HashMap::new();
     impl_test!(hashes, ());
     impl_test!(hashes, true);
@@ -53,10 +55,11 @@ fn test_type_hash_collision() {
     impl_test!(hashes, vec![1_i8, 2, 3, 4, 5].as_slice());
 
     dbg!(hashes);
+    Ok(())
 }
 
 #[test]
-fn test_type_hash_const_type_parameters() {
+fn test_type_hash_const_type_parameters() -> Result<()> {
     #[derive(epserde::Epserde)]
     struct S<const N: usize>(std::marker::PhantomData<[u8; N]>);
 
@@ -66,4 +69,5 @@ fn test_type_hash_const_type_parameters() {
     S::<1>::type_hash(&mut hasher1);
     dbg!(hasher0.finish(), hasher1.finish());
     assert_ne!(hasher0.finish(), hasher1.finish());
+    Ok(())
 }

--- a/epserde/tests/test_types.rs
+++ b/epserde/tests/test_types.rs
@@ -7,113 +7,121 @@
 use epserde::prelude::*;
 use maligned::A16;
 use std::iter;
+use anyhow::Result;
 
 macro_rules! impl_test {
     ($ty:ty, $val:expr) => {{
         let a = $val;
         let mut cursor = <AlignedCursor<A16>>::new();
 
-        let mut schema = unsafe { a.serialize_with_schema(&mut cursor).unwrap() };
+        let mut schema = unsafe { a.serialize_with_schema(&mut cursor)? };
         schema.0.sort_by_key(|a| a.offset);
         println!("{}", schema.to_csv());
 
         cursor.set_position(0);
-        let a1 = unsafe { <$ty>::deserialize_full(&mut cursor).unwrap() };
+        let a1 = unsafe { <$ty>::deserialize_full(&mut cursor)? };
         assert_eq!(a, a1);
 
-        let a2 = unsafe { <$ty>::deserialize_eps(cursor.as_bytes()).unwrap() };
+        let a2 = unsafe { <$ty>::deserialize_eps(cursor.as_bytes())? };
         assert_eq!(a, a2);
     }};
 }
 
 #[test]
-fn test_array_usize() {
+fn test_array_usize() -> Result<()> {
     let a = [1, 2, 3, 4, 5];
 
     let mut cursor = <AlignedCursor<A16>>::new();
-    let mut schema = unsafe { a.serialize_with_schema(&mut cursor).unwrap() };
+    let mut schema = unsafe { a.serialize_with_schema(&mut cursor)? };
     schema.0.sort_by_key(|a| a.offset);
     println!("{}", schema.to_csv());
 
     cursor.set_position(0);
-    let a1 = unsafe { <[usize; 5]>::deserialize_full(&mut cursor).unwrap() };
+    let a1 = unsafe { <[usize; 5]>::deserialize_full(&mut cursor)? };
     assert_eq!(a, a1);
 
-    let a2 = unsafe { <[usize; 5]>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let a2 = unsafe { <[usize; 5]>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *a2);
+    Ok(())
 }
 
 #[test]
-fn test_vec_usize() {
-    impl_test!(Vec<usize>, vec![1, 2, 3, 4, 5])
+fn test_vec_usize() -> Result<()> {
+    impl_test!(Vec<usize>, vec![1, 2, 3, 4, 5]);
+    Ok(())
 }
 
 #[test]
-fn test_box_slice_usize() {
+fn test_box_slice_usize() -> Result<()> {
     let a = vec![1, 2, 3, 4, 5].into_boxed_slice();
 
     let mut cursor = <AlignedCursor<A16>>::new();
-    let mut schema = unsafe { a.serialize_with_schema(&mut cursor).unwrap() };
+    let mut schema = unsafe { a.serialize_with_schema(&mut cursor)? };
     schema.0.sort_by_key(|a| a.offset);
     println!("{}", schema.to_csv());
 
     cursor.set_position(0);
-    let a1 = unsafe { <Box<[usize]>>::deserialize_full(&mut cursor).unwrap() };
+    let a1 = unsafe { <Box<[usize]>>::deserialize_full(&mut cursor)? };
     assert_eq!(a, a1);
 
-    let a2 = unsafe { <Box<[usize]>>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let a2 = unsafe { <Box<[usize]>>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, a2.into());
+    Ok(())
 }
 
 #[test]
-fn test_box_slice_string() {
+fn test_box_slice_string() -> Result<()> {
     let a = vec!["A".to_string(), "V".to_string()].into_boxed_slice();
 
     let mut cursor = <AlignedCursor<A16>>::new();
-    let mut schema = unsafe { a.serialize_with_schema(&mut cursor).unwrap() };
+    let mut schema = unsafe { a.serialize_with_schema(&mut cursor)? };
     schema.0.sort_by_key(|a| a.offset);
     println!("{}", schema.to_csv());
 
     cursor.set_position(0);
-    let a1 = unsafe { <Box<[String]>>::deserialize_full(&mut cursor).unwrap() };
+    let a1 = unsafe { <Box<[String]>>::deserialize_full(&mut cursor)? };
     assert_eq!(a, a1);
 
-    let a2 = unsafe { <Box<[String]>>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let a2 = unsafe { <Box<[String]>>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a.len(), a2.len());
     a.iter().zip(a2.iter()).for_each(|(a, a2)| {
         assert_eq!(a, a2);
     });
+    Ok(())
 }
 
 #[test]
-fn test_vec_vec_usize() {
-    impl_test!(Vec<Vec<usize>>, vec![vec![1, 2, 3], vec![4, 5]])
+fn test_vec_vec_usize() -> Result<()> {
+    impl_test!(Vec<Vec<usize>>, vec![vec![1, 2, 3], vec![4, 5]]);
+    Ok(())
 }
 
 #[test]
-fn test_vec_array_string() {
+fn test_vec_array_string() -> Result<()> {
     impl_test!(
         Vec<[String; 2]>,
         vec![
             ["a".to_string(), "b".to_string()],
             ["c".to_string(), "aasfihjasomk".to_string()]
         ]
-    )
+    );
+    Ok(())
 }
 
 #[test]
-fn test_vec_vec_string() {
+fn test_vec_vec_string() -> Result<()> {
     impl_test!(
         Vec<Vec<String>>,
         vec![
             vec!["a".to_string(), "b".to_string()],
             vec!["c".to_string(), "aasfihjasomk".to_string()]
         ]
-    )
+    );
+    Ok(())
 }
 
 #[test]
-fn test_vec_vec_array_array_string() {
+fn test_vec_vec_array_array_string() -> Result<()> {
     impl_test!(
         Vec<Vec<[[String; 2]; 2]>>,
         vec![
@@ -126,19 +134,21 @@ fn test_vec_vec_array_array_string() {
                 ["c".to_string(), "d".to_string()],
             ]],
         ]
-    )
+    );
+    Ok(())
 }
 
 #[test]
-fn test_vec_vec_array_array_usize() {
+fn test_vec_vec_array_array_usize() -> Result<()> {
     impl_test!(
         Vec<Vec<[[usize; 2]; 2]>>,
         vec![vec![[[1, 2], [3, 4],]], vec![[[5, 6], [7, 8],]],]
-    )
+    );
+    Ok(())
 }
 
 #[test]
-fn test_struct_deep() {
+fn test_struct_deep() -> Result<()> {
     #[derive(Epserde, Copy, Clone, Debug, PartialEq)]
     struct Struct {
         a: usize,
@@ -148,19 +158,20 @@ fn test_struct_deep() {
     let a = Struct { a: 0, b: 1, c: 2 };
     let mut cursor = <AlignedCursor<A16>>::new();
     // Serialize
-    let _bytes_written = unsafe { a.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { a.serialize(&mut cursor)? };
 
     cursor.set_position(0);
-    let full = unsafe { <Struct>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Struct>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
 
     cursor.set_position(0);
-    let eps = unsafe { <Struct>::deserialize_full(&mut cursor).unwrap() };
+    let eps = unsafe { <Struct>::deserialize_full(&mut cursor)? };
     assert_eq!(a, eps);
+    Ok(())
 }
 
 #[test]
-fn test_struct_zero() {
+fn test_struct_zero() -> Result<()> {
     #[derive(Epserde, Copy, Clone, Debug, PartialEq)]
     #[repr(C)]
     #[zero_copy]
@@ -172,36 +183,38 @@ fn test_struct_zero() {
     let a = Struct { a: 0, b: 1, c: 2 };
     let mut cursor = <AlignedCursor<A16>>::new();
     // Serialize
-    let _bytes_written = unsafe { a.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { a.serialize(&mut cursor)? };
 
     cursor.set_position(0);
-    let full = unsafe { <Struct>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Struct>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
 
     cursor.set_position(0);
-    let eps = unsafe { <Struct>::deserialize_full(&mut cursor).unwrap() };
+    let eps = unsafe { <Struct>::deserialize_full(&mut cursor)? };
     assert_eq!(a, eps);
+    Ok(())
 }
 
 #[test]
-fn test_tuple_struct_deep() {
+fn test_tuple_struct_deep() -> Result<()> {
     #[derive(Epserde, Copy, Clone, Debug, PartialEq)]
     struct Tuple(usize, usize, i32);
     let a = Tuple(0, 1, 2);
     let mut cursor = <AlignedCursor<A16>>::new();
     // Serialize
-    let _bytes_written = unsafe { a.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { a.serialize(&mut cursor)? };
 
     cursor.set_position(0);
-    let full = unsafe { <Tuple>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Tuple>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
 
-    let eps = unsafe { <Tuple>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Tuple>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, eps);
+    Ok(())
 }
 
 #[test]
-fn test_tuple_struct_zero() {
+fn test_tuple_struct_zero() -> Result<()> {
     #[derive(Epserde, Copy, Clone, Debug, PartialEq)]
     #[repr(C)]
     #[zero_copy]
@@ -209,18 +222,19 @@ fn test_tuple_struct_zero() {
     let a = Tuple(0, 1, 2);
     let mut cursor = <AlignedCursor<A16>>::new();
     // Serialize
-    let _bytes_written = unsafe { a.serialize(&mut cursor).unwrap() };
+    let _bytes_written = unsafe { a.serialize(&mut cursor)? };
 
     cursor.set_position(0);
-    let full = unsafe { <Tuple>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Tuple>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
 
-    let eps = unsafe { <Tuple>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Tuple>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *eps);
+    Ok(())
 }
 
 #[test]
-fn test_enum_deep() {
+fn test_enum_deep() -> Result<()> {
     #[derive(Epserde, Clone, Debug, PartialEq)]
     enum Data<V = Vec<usize>> {
         A,
@@ -232,29 +246,29 @@ fn test_enum_deep() {
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::A;
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert!(matches!(eps, Data::A));
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::B(3);
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert!(matches!(eps, Data::B(3)));
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::C(4, vec![1, 2, 3]);
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert!(matches!(eps, Data::C(4, _)));
 
     let mut cursor = <AlignedCursor<A16>>::new();
@@ -262,36 +276,37 @@ fn test_enum_deep() {
         a: 1,
         b: vec![1, 2],
     };
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data<Vec<i32>>>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data<Vec<i32>>>::deserialize_full(&mut cursor)? };
     assert!(matches!(full, Data::D { a: 1, b: _ }));
-    let eps = unsafe { <Data<Vec<i32>>>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data<Vec<i32>>>::deserialize_eps(cursor.as_bytes())? };
     assert!(matches!(eps, Data::D { a: 1, b: [1, 2] }));
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::E;
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert!(matches!(eps, Data::E));
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Vec::from_iter(iter::repeat(Data::A).take(10));
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Vec<Data>>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Vec<Data>>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Vec<Data>>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Vec<Data>>::deserialize_eps(cursor.as_bytes())? };
     for e in eps {
         assert!(matches!(e, Data::A));
     }
+    Ok(())
 }
 
 #[test]
-fn test_enum_zero() {
+fn test_enum_zero() -> Result<()> {
     #[derive(Epserde, Clone, Copy, Debug, PartialEq)]
     #[repr(C)]
     #[zero_copy]
@@ -304,46 +319,47 @@ fn test_enum_zero() {
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::A;
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *eps);
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::B(3);
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *eps);
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::C(4);
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *eps);
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Data::D { a: 1, b: 2 };
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Data>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Data>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Data>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *eps);
 
     let mut cursor = <AlignedCursor<A16>>::new();
     let a = Vec::from_iter(iter::repeat(Data::A).take(10));
-    unsafe { a.serialize(&mut cursor).unwrap() };
+    unsafe { a.serialize(&mut cursor)? };
     cursor.set_position(0);
-    let full = unsafe { <Vec<Data>>::deserialize_full(&mut cursor).unwrap() };
+    let full = unsafe { <Vec<Data>>::deserialize_full(&mut cursor)? };
     assert_eq!(a, full);
-    let eps = unsafe { <Vec<Data>>::deserialize_eps(cursor.as_bytes()).unwrap() };
+    let eps = unsafe { <Vec<Data>>::deserialize_eps(cursor.as_bytes())? };
     assert_eq!(a, *eps);
+    Ok(())
 }

--- a/epserde/tests/test_zero.rs
+++ b/epserde/tests/test_zero.rs
@@ -6,29 +6,30 @@
 
 use epserde::prelude::*;
 use maligned::A16;
+use anyhow::Result;
 
 macro_rules! impl_test {
     ($ty:ty, $data:expr) => {{
         let mut cursor = <AlignedCursor<A16>>::new();
 
-        let _ = unsafe { $data.serialize_with_schema(&mut cursor).unwrap() };
+        let _ = unsafe { $data.serialize_with_schema(&mut cursor)? };
 
         cursor.set_position(0);
-        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor).unwrap() };
+        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor)? };
         assert_eq!($data, full_copy);
 
-        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes()).unwrap() };
+        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes())? };
         assert_eq!($data, *eps_copy);
     }
     {
         let mut cursor = <AlignedCursor<A16>>::new();
-        unsafe { $data.serialize(&mut cursor).unwrap() };
+        unsafe { $data.serialize(&mut cursor)? };
 
         cursor.set_position(0);
-        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor).unwrap() };
+        let full_copy = unsafe { <$ty>::deserialize_full(&mut cursor)? };
         assert_eq!($data, full_copy);
 
-        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes()).unwrap() };
+        let eps_copy = unsafe { <$ty>::deserialize_eps(cursor.as_bytes())? };
         assert_eq!($data, *eps_copy);
     }};
 }
@@ -36,8 +37,9 @@ macro_rules! impl_test {
 macro_rules! test_zero {
     ($test_name:ident, $ty:ty, $data: expr) => {
         #[test]
-        fn $test_name() {
+        fn $test_name() -> Result<()> {
             impl_test!($ty, $data);
+            Ok(())
         }
     };
 }


### PR DESCRIPTION
This commit refactors all tests in the `epserde/tests` directory to return `anyhow::Result<()>` instead of `()`.

This change makes the tests cleaner and more consistent. It also allows the use of the `?` operator for error handling within the tests, which makes the code more readable.

The following changes were made to each test file:
- Added `use anyhow::Result;` at the beginning of the file.
- Changed the function signature of each test to `-> Result<()>`.
- Replaced `.unwrap()` calls with the `?` operator.
- Added `Ok(())` at the end of each test function.