### PR TITLE
Make CopyType unsafe

### DIFF
--- a/epserde-derive/src/lib.rs
+++ b/epserde-derive/src/lib.rs
@@ -486,7 +486,7 @@ fn gen_epserde_struct_impl(ctx: &EpserdeContext, s: &syn::DataStruct) -> proc_ma
         // replaced with their SerType/DeserType.
         quote! {
             #[automatically_derived]
-            impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
+            unsafe impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
                 type Copy = ::epserde::traits::Zero;
             }
 
@@ -540,7 +540,7 @@ fn gen_epserde_struct_impl(ctx: &EpserdeContext, s: &syn::DataStruct) -> proc_ma
 
         quote! {
             #[automatically_derived]
-            impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
+            unsafe impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
                 type Copy = ::epserde::traits::Deep;
             }
 
@@ -757,7 +757,7 @@ fn gen_epserde_enum_impl(ctx: &EpserdeContext, e: &syn::DataEnum) -> proc_macro2
         // replaced with their SerType/DeserType.
         quote! {
             #[automatically_derived]
-            impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
+            unsafe impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
                 type Copy = ::epserde::traits::Zero;
             }
 
@@ -810,7 +810,7 @@ fn gen_epserde_enum_impl(ctx: &EpserdeContext, e: &syn::DataEnum) -> proc_macro2
 
         quote! {
             #[automatically_derived]
-            impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
+            unsafe impl #generics_for_impl ::epserde::traits::CopyType for #name #generics_for_type #where_clause {
                 type Copy = ::epserde::traits::Deep;
             }
             #[automatically_derived]

--- a/epserde/src/impls/array.rs
+++ b/epserde/src/impls/array.rs
@@ -13,7 +13,7 @@ use core::mem::MaybeUninit;
 use deser::*;
 use ser::*;
 
-impl<T: CopyType, const N: usize> CopyType for [T; N] {
+unsafe impl<T: CopyType, const N: usize> CopyType for [T; N] {
     type Copy = T::Copy;
 }
 

--- a/epserde/src/impls/boxed_slice.rs
+++ b/epserde/src/impls/boxed_slice.rs
@@ -13,7 +13,7 @@ use core::hash::Hash;
 use deser::*;
 use ser::*;
 
-impl<T> CopyType for Box<[T]> {
+unsafe impl<T> CopyType for Box<[T]> {
     type Copy = Deep;
 }
 

--- a/epserde/src/impls/iter.rs
+++ b/epserde/src/impls/iter.rs
@@ -26,7 +26,7 @@ use ser::*;
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct SerIter<'a, T: 'a, I: ExactSizeIterator<Item = &'a T>>(RefCell<I>);
 
-impl<'a, T: ZeroCopy + TypeHash, I: ExactSizeIterator<Item = &'a T>> CopyType
+unsafe impl<'a, T: ZeroCopy + TypeHash, I: ExactSizeIterator<Item = &'a T>> CopyType
     for SerIter<'a, T, I>
 {
     type Copy = Deep;

--- a/epserde/src/impls/prim.rs
+++ b/epserde/src/impls/prim.rs
@@ -21,7 +21,7 @@ use ser::*;
 
 macro_rules! impl_prim_type_hash {
     ($($ty:ty),*) => {$(
-        impl CopyType for $ty {
+        unsafe impl CopyType for $ty {
             type Copy = Zero;
         }
 
@@ -254,7 +254,7 @@ impl DeserializeInner for () {
 // but it does have to implement TypeHash, as we must be able to tell
 // apart structures with different type parameters stored in a PhantomData.
 
-impl<T: ?Sized> CopyType for PhantomData<T> {
+unsafe impl<T: ?Sized> CopyType for PhantomData<T> {
     type Copy = Zero;
 }
 
@@ -304,7 +304,7 @@ impl<T: ?Sized> DeserializeInner for PhantomData<T> {
 
 // Options are deep-copy types serialized as a one-byte tag (0 for None, 1 for Some) followed, in case, by the value.
 
-impl<T> CopyType for Option<T> {
+unsafe impl<T> CopyType for Option<T> {
     type Copy = Deep;
 }
 

--- a/epserde/src/impls/stdlib.rs
+++ b/epserde/src/impls/stdlib.rs
@@ -31,7 +31,7 @@ impl TypeHash for DefaultHasher {
 
 macro_rules! impl_ranges {
     ($ty:ident) => {
-        impl<Idx: ZeroCopy> CopyType for core::ops::$ty<Idx> {
+        unsafe impl<Idx: ZeroCopy> CopyType for core::ops::$ty<Idx> {
             type Copy = Deep;
         }
 
@@ -65,7 +65,7 @@ impl_ranges!(RangeToInclusive);
 
 // RangeFull is a zero-sized type, so it is always zero-copy.
 
-impl CopyType for core::ops::RangeFull {
+unsafe impl CopyType for core::ops::RangeFull {
     type Copy = Zero;
 }
 
@@ -271,7 +271,7 @@ impl DeserializeInner for core::ops::RangeFull {
     }
 }
 
-impl<T: CopyType> CopyType for core::ops::Bound<T> {
+unsafe impl<T: CopyType> CopyType for core::ops::Bound<T> {
     type Copy = Deep;
 }
 
@@ -340,7 +340,7 @@ impl<T: DeserializeInner> DeserializeInner for core::ops::Bound<T> {
     }
 }
 
-impl<B: CopyType, C: CopyType> CopyType for core::ops::ControlFlow<B, C> {
+unsafe impl<B: CopyType, C: CopyType> CopyType for core::ops::ControlFlow<B, C> {
     type Copy = Deep;
 }
 

--- a/epserde/src/impls/string.rs
+++ b/epserde/src/impls/string.rs
@@ -12,7 +12,7 @@ use core::hash::Hash;
 use deser::*;
 use ser::*;
 
-impl CopyType for String {
+unsafe impl CopyType for String {
     type Copy = Deep;
 }
 
@@ -82,7 +82,7 @@ impl DeserializeInner for String {
     }
 }
 
-impl CopyType for Box<str> {
+unsafe impl CopyType for Box<str> {
     type Copy = Deep;
 }
 

--- a/epserde/src/impls/tuple.rs
+++ b/epserde/src/impls/tuple.rs
@@ -47,7 +47,7 @@ macro_rules! impl_type_hash {
 
 macro_rules! impl_tuples {
     ($($t:ident),*) => {
-        impl<T: ZeroCopy> CopyType for ($($t,)*)  {
+        unsafe impl<T: ZeroCopy> CopyType for ($($t,)*)  {
             type Copy = Zero;
 		}
 

--- a/epserde/src/impls/vec.rs
+++ b/epserde/src/impls/vec.rs
@@ -18,7 +18,7 @@ use crate::traits::*;
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::vec::Vec;
 
-impl<T> CopyType for Vec<T> {
+unsafe impl<T> CopyType for Vec<T> {
     type Copy = Deep;
 }
 

--- a/epserde/src/lib.rs
+++ b/epserde/src/lib.rs
@@ -121,7 +121,7 @@ impl<T: DeserializeInner> PhantomDeserData<T> {
     }
 }
 
-impl<T: ?Sized> CopyType for PhantomDeserData<T> {
+unsafe impl<T: ?Sized> CopyType for PhantomDeserData<T> {
     type Copy = Zero;
 }
 

--- a/epserde/src/traits/copy_type.rs
+++ b/epserde/src/traits/copy_type.rs
@@ -83,7 +83,13 @@ impl CopySelector for Deep {
 /// If you use the provided derive macros all this logic will be hidden from
 /// you. You'll just have to add `#[zero_copy]` to your structures (if you want
 /// them to be zero-copy) and ε-serde will do the rest.
-pub trait CopyType: Sized {
+///
+/// # Safety
+/// The trait is unsafe because the user must guarantee that the type is either
+/// zero-copy or deep-copy, and this cannot be checked by the compiler. In
+/// particular, if you implement `CopyType` with `Copy = Zero` you must guarantee
+/// that the type is `repr(C)`, has no padding bytes, and no pointers.
+pub unsafe trait CopyType: Sized {
     type Copy: CopySelector;
 }
 


### PR DESCRIPTION
The `CopyType` trait is used to mark types as zero-copy or deep-copy. This is a fundamental property of the type that the compiler cannot check. For this reason, the trait should be `unsafe`.

This commit makes the `CopyType` trait `unsafe` and updates all implementations of the trait to be `unsafe`. This includes the implementations for primitive types, standard library types, and the implementations generated by the `epserde-derive` crate.